### PR TITLE
Fix: Update sockets to only render after checking logged in users state

### DIFF
--- a/client/socket.js
+++ b/client/socket.js
@@ -2,7 +2,6 @@ import io from 'socket.io-client'
 import store from './store'
 import {fetchAllTasks} from './store/all-tasks'
 import {
-  fetchSingleBoard,
   addedUsersSingleBoard,
   removedUserSingleBoard
 } from './store/single-board'
@@ -13,20 +12,25 @@ socket.on('connect', () => {
   console.log('Connected!')
 })
 
-// socket.on('all-tasks', tasks => {
-//   store.dispatch(fetchAllTasks(tasks))
-// })
-
-socket.on('singleBoard', board => {
-  store.dispatch(fetchSingleBoard(board))
+socket.on('all-tasks', tasks => {
+  const state = store.getState()
+  if (state.user && state.singleBoard.id === tasks[0].boardId) {
+    store.dispatch(fetchAllTasks(tasks))
+  }
 })
 
 socket.on('add-user', board => {
-  store.dispatch(addedUsersSingleBoard(board))
+  const state = store.getState()
+  if (state.user && state.singleBoard.id === board.id) {
+    store.dispatch(addedUsersSingleBoard(board))
+  }
 })
 
 socket.on('remove-user', board => {
-  store.dispatch(removedUserSingleBoard(board))
+  const state = store.getState()
+  if (state.user && state.singleBoard.id === board.id) {
+    store.dispatch(removedUserSingleBoard(board))
+  }
 })
 
 export default socket

--- a/client/store/all-tasks.js
+++ b/client/store/all-tasks.js
@@ -21,7 +21,7 @@ export const getAllTasks = boardId => async dispatch => {
   try {
     const {data} = await axios.get(`/api/tasks/allTasks/${boardId}`)
     dispatch(fetchAllTasks(data))
-    // socket.emit('all-tasks', data)
+    socket.emit('all-tasks', data)
   } catch (err) {
     console.error(err)
   }

--- a/client/store/single-board.js
+++ b/client/store/single-board.js
@@ -30,7 +30,7 @@ export const getSingleBoard = boardId => async dispatch => {
   try {
     const {data} = await axios.get(`/api/boards/${boardId}`)
     dispatch(fetchSingleBoard(data))
-    socket.emit('singleBoard', data)
+    // socket.emit('singleBoard', data)
   } catch (err) {
     dispatch(fetchSingleBoard({error: err}))
   }

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -8,13 +8,10 @@ module.exports = io => {
       console.log(`Connection ${socket.id} has left the building`)
     })
 
-    // socket.on('all-tasks', tasks => {
-    //   socket.broadcast.emit('all-tasks', tasks)
-    // })
-
-    socket.on('singleBoard', board => {
-      socket.broadcast.emit('singleBoard', board)
+    socket.on('all-tasks', tasks => {
+      socket.broadcast.emit('all-tasks', tasks)
     })
+
     socket.on('add-user', board => {
       socket.broadcast.emit('add-user', board)
     })


### PR DESCRIPTION
Fixed sockets:

Brought in state to sockets component, it checks user's current board state before emitting the sockets. So now sockets should only emit if the board Id of the triggered action creator dispatch and current logged in user board state match